### PR TITLE
Adicionar dados do SAC nos boletos da Caixa [REC-76]

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -101,6 +101,11 @@ module Brcobranca
         File.join(File.dirname(__FILE__), '..', 'arquivos', 'logos', "#{class_name}.eps")
       end
 
+      # @return [String] Informações adicionar no recibo do pagador.
+      def info_recibo_pagador
+        ""
+      end
+
       # Dígito verificador do banco
       # @return [Integer] 1 caracteres numéricos.
       def banco_dv

--- a/lib/brcobranca/boleto/caixa.rb
+++ b/lib/brcobranca/boleto/caixa.rb
@@ -61,6 +61,10 @@ module Brcobranca
         SIGLA_CARTEIRA[carteira]
       end
 
+      def info_recibo_pagador
+        "SAC CAIXA: 0800 726 0101 (informações, reclamações, sugestões e elogios)\nPara pessoas com deficiência auditiva ou de fala: 0800 726 2492\nOuvidoria: 0800 725 7474\ncaixa.gov.br"
+      end
+
       # Nosso número, 17 dígitos
       #  1 à 2: carteira
       #  3 à 17: campo_livre

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -162,6 +162,7 @@ module Brcobranca
           doc.show [boleto.sacado, boleto.sacado_documento.try(:formata_documento)].compact.join(' - ')
           doc.moveto x: '0.7 cm', y: '20.55 cm'
           doc.show "#{boleto.sacado_endereco}", :tag => :pequeno
+          doc.text_area boleto.info_recibo_pagador, x: '0.55 cm', y: '19.70 cm', row_height: 0.3, tag: :pequeno
           # FIM Primeira parte do BOLETO
         end
 


### PR DESCRIPTION
Adiciona informações sobre o SAC da Caixa no recibo do pagador.
