### PR TITLE
Atualiza tamanho do campo convenio para o Santander

### DIFF
--- a/lib/brcobranca/boleto/santander.rb
+++ b/lib/brcobranca/boleto/santander.rb
@@ -8,7 +8,7 @@ module Brcobranca
       attr_reader :seu_numero
 
       validates_length_of :agencia, maximum: 4, message: 'deve ser menor ou igual a 4 dígitos.'
-      validates_length_of :convenio, maximum: 7, message: 'deve ser menor ou igual a 7 dígitos.'
+      validates_length_of :convenio, maximum: 9, message: 'deve ser menor ou igual a 9 dígitos.'
       validates_length_of :numero_documento, maximum: 12, message: 'deve ser menor ou igual a 12 dígitos.'
       validates_length_of :seu_numero, maximum: 7, message: 'deve ser menor ou igual a 7 dígitos.'
 

--- a/spec/brcobranca/santander_spec.rb
+++ b/spec/brcobranca/santander_spec.rb
@@ -17,7 +17,7 @@ describe Brcobranca::Boleto::Santander do
       sacado: 'Claudio Pozzebom',
       sacado_documento: '12345678900',
       agencia: '0059',
-      convenio: 1_899_775,
+      convenio: 123_456_789,
       numero_documento: '90000267'
     }
   end
@@ -58,7 +58,7 @@ describe Brcobranca::Boleto::Santander do
     expect(boleto_novo.sacado).to eql('Claudio Pozzebom')
     expect(boleto_novo.sacado_documento).to eql('12345678900')
     expect(boleto_novo.agencia).to eql('0059')
-    expect(boleto_novo.convenio).to eql('1899775')
+    expect(boleto_novo.convenio).to eql('123456789')
     expect(boleto_novo.numero_documento).to eql('90000267')
     expect(boleto_novo.carteira).to eql('102')
   end


### PR DESCRIPTION
## Motivação
O boleto Santander tem como padrão para o tamanho máximo do campo `convenio` **9** caracteres.
Atualmente o limite é de **7** caracteres.

## Solução proposta
Alterar o tamanho do campo 