### PR TITLE
Nova apresentação p/ boletos online Banco do Brasil

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -99,6 +99,7 @@ module Brcobranca
     autoload :Base,          'brcobranca/boleto/base'
     autoload :BaseV2,        'brcobranca/boleto/base_v2'
     autoload :BancoBrasil,   'brcobranca/boleto/banco_brasil'
+    autoload :BancoBrasilV2,   'brcobranca/boleto/banco_brasil_v2'
     autoload :Itau,          'brcobranca/boleto/itau'
     autoload :Hsbc,          'brcobranca/boleto/hsbc'
     autoload :Bradesco,      'brcobranca/boleto/bradesco'

--- a/lib/brcobranca/boleto/banco_brasil_v2.rb
+++ b/lib/brcobranca/boleto/banco_brasil_v2.rb
@@ -1,0 +1,105 @@
+module Brcobranca
+  module Boleto
+    class BancoBrasilV2 < BaseV2 # Banco do Brasil
+      attr_accessor :codigo_barras
+      attr_reader :linha_digitavel
+
+      LINHA_DIGITAVEL_REGEXP = /^(.{5})(.{5})(.{5})(.{6})(.{5})(.{6})(.{1})(.{14})$/.freeze
+      VALID_LINHA_DIGITAVEL_REGEXP = /^(\d{5})(\d{5})(\d{23})(\d{14})$/.freeze
+      NOME_BANCO = 'bancobrasil'
+
+      # Nova instancia do BancoBrasil
+      # @param (see Brcobranca::Boleto::Base#initialize)
+      def initialize(campos = {})
+        @codigo_barras = campos.dig(:codigo_barras)
+        @linha_digitavel = campos.dig(:linha_digitavel)
+
+        campos[:carteira] = '17'
+        super(campos)
+      end
+
+      # Codigo do banco emissor (3 dígitos sempre)
+      #
+      # @return [String] 3 caracteres numéricos.
+      def banco
+        '001'
+      end
+
+      # Carteira
+      #
+      # @return [String] 2 caracteres numéricos.
+      def carteira=(valor)
+        @carteira = valor.to_s.rjust(2, '0') if valor
+      end
+
+      # Dígito verificador do banco
+      #
+      # @return [String] 1 caracteres numéricos.
+      def banco_dv
+        banco.modulo11_9to2_10_como_x
+      end
+
+      # Retorna dígito verificador da agência
+      #
+      # @return [String] 1 caracteres numéricos.
+      def agencia_dv
+        agencia.modulo11_9to2_10_como_x
+      end
+
+      # Conta corrente
+      # @return [String] 8 caracteres numéricos.
+      def conta_corrente=(valor)
+        @conta_corrente = valor.to_s.rjust(8, '0') if valor
+      end
+
+      # Dígito verificador da conta corrente
+      # @return [String] 1 caracteres numéricos.
+      def conta_corrente_dv
+        conta_corrente.modulo11_9to2_10_como_x
+      end
+
+      # Número seqüencial utilizado para identificar o boleto.
+      def numero_documento
+        @numero_documento.to_s.rjust(10, '0')
+      end
+
+      # Dígito verificador do nosso número.
+      # @return [String] 1 caracteres numéricos.
+      # @see BancoBrasil#numero_documento
+      def nosso_numero_dv
+        "#{convenio}#{numero_documento}".modulo11_9to2_10_como_x
+      end
+
+      # Nosso número para exibir no boleto.
+      # @return [String]
+      # @example
+      #  boleto.nosso_numero_boleto #=> "12387989000004042-4"
+      def nosso_numero_boleto
+        "000#{convenio}#{numero_documento}"
+      end
+
+      # Agência + conta corrente do cliente para exibir no boleto.
+      # @return [String]
+      # @example
+      #  boleto.agencia_conta_boleto #=> "0548-7 / 00001448-6"
+      def agencia_conta_boleto
+        "#{agencia}-#{agencia_dv} / #{conta_corrente}-#{conta_corrente_dv}"
+      end
+
+      def linha_digitavel=(linha_digitavel_bb)
+        unless linha_digitavel_bb =~ VALID_LINHA_DIGITAVEL_REGEXP
+          raise ArgumentError, "#{linha_digitavel_bb} Linha digitável precisa conter 47 caracteres numéricos."
+        end
+
+        @linha_digitavel = linha_digitavel_bb.gsub(LINHA_DIGITAVEL_REGEXP, '\1.\2 \3.\4 \5.\6 \7 \8')
+      end
+
+      def nosso_numero_boleto=(nosso_numero_bb)
+        ultima_posicao_nosso_numero_str = nosso_numero_bb.size - 1
+        nosso_numero_str = String.new(nosso_numero_bb)
+
+        @nosso_numero_boleto = nosso_numero_str.insert(ultima_posicao_nosso_numero_str, '-')
+      end
+    end
+  end
+end

--- a/lib/brcobranca/boleto/base_v2.rb
+++ b/lib/brcobranca/boleto/base_v2.rb
@@ -81,8 +81,6 @@ module Brcobranca
       validates_numericality_of :convenio, :agencia, :conta_corrente,
                                 :numero_documento, message: 'não é um número.', allow_nil: true
 
-      NOME_BANCO = 'santander'
-
       # Nova instancia da classe Base
       # @param [Hash] campos
       def initialize(campos = {})
@@ -103,7 +101,7 @@ module Brcobranca
       # Logotipo do banco
       # @return [Path] Caminho para o arquivo de logotipo do banco.
       def logotipo
-        File.join(File.dirname(__FILE__), '..', 'arquivos', 'logos', "#{NOME_BANCO}.eps")
+        File.join(File.dirname(__FILE__), '..', 'arquivos', 'logos', "#{class_name.gsub('v2', '')}.eps")
       end
 
       # @return [String] Informações adicionar no recibo do pagador.

--- a/spec/brcobranca/banco_brasil_v2_spec.rb
+++ b/spec/brcobranca/banco_brasil_v2_spec.rb
@@ -1,0 +1,123 @@
+# -*- encoding: utf-8 -*-
+require 'spec_helper'
+
+describe Brcobranca::Boleto::BancoBrasilV2 do #:nodoc:[all]
+
+  before(:each) do
+    @valid_attributes = {
+      especie_documento: 'DM',
+      moeda: '9',
+      data_documento: Date.today,
+      dias_vencimento: 1,
+      aceite: 'S',
+      quantidade: 1,
+      valor: 0.0,
+      local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
+      cedente: 'Kivanio Barbosa',
+      documento_cedente: '12345678912',
+      sacado: 'Claudio Pozzebom',
+      sacado_documento: '12345678900',
+      agencia: '4042',
+      conta_corrente: '61900',
+      convenio: 12_387_989,
+      numero_documento: '777700168',
+      linha_digitavel: '03399276911310000000200000101014381000000001000',
+      codigo_barras: '03393810000000010009276913100000000000010101'
+    }
+  end
+
+  it 'Criar nova instancia com atributos padrões' do
+    boleto_novo = described_class.new
+    expect(boleto_novo.banco).to eql('001')
+    expect(boleto_novo.especie_documento).to eql('DM')
+    expect(boleto_novo.especie).to eql('R$')
+    expect(boleto_novo.moeda).to eql('9')
+    expect(boleto_novo.data_documento).to eql(Date.today)
+    expect(boleto_novo.dias_vencimento).to eql(1)
+    expect(boleto_novo.data_vencimento).to eql(Date.today + 1)
+    expect(boleto_novo.aceite).to eql('S')
+    expect(boleto_novo.quantidade).to eql(1)
+    expect(boleto_novo.valor).to eql(0.0)
+    expect(boleto_novo.valor_documento).to eql(0.0)
+    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    expect(boleto_novo.carteira).to eql('17')
+    expect(boleto_novo.codigo_servico).to be_falsey
+    expect(boleto_novo.linha_digitavel).to be_blank
+    expect(boleto_novo.codigo_barras).to be_blank
+    expect(boleto_novo.nosso_numero_boleto).to eq '0000000000000'
+  end
+
+  it 'Criar nova instancia com atributos válidos' do
+    boleto_novo = described_class.new(@valid_attributes)
+    expect(boleto_novo.banco).to eql('001')
+    expect(boleto_novo.especie_documento).to eql('DM')
+    expect(boleto_novo.especie).to eql('R$')
+    expect(boleto_novo.moeda).to eql('9')
+    expect(boleto_novo.data_documento).to eql(Date.today)
+    expect(boleto_novo.dias_vencimento).to eql(1)
+    expect(boleto_novo.data_vencimento).to eql(Date.today + 1)
+    expect(boleto_novo.aceite).to eql('S')
+    expect(boleto_novo.quantidade).to eql(1)
+    expect(boleto_novo.valor).to eql(0.0)
+    expect(boleto_novo.valor_documento).to eql(0.0)
+    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    expect(boleto_novo.cedente).to eql('Kivanio Barbosa')
+    expect(boleto_novo.documento_cedente).to eql('12345678912')
+    expect(boleto_novo.sacado).to eql('Claudio Pozzebom')
+    expect(boleto_novo.sacado_documento).to eql('12345678900')
+    expect(boleto_novo.conta_corrente).to eql('00061900')
+    expect(boleto_novo.agencia).to eql('4042')
+    expect(boleto_novo.convenio).to eql(12_387_989)
+    expect(boleto_novo.numero_documento).to eql('0777700168')
+    expect(boleto_novo.carteira).to eql('17')
+    expect(boleto_novo.codigo_servico).to be_falsey
+    expect(boleto_novo.linha_digitavel).to eq('03399.27691 13100.000002 00000.101014 3 81000000001000')
+    expect(boleto_novo.codigo_barras).to eq('03393810000000010009276913100000000000010101')
+    expect(boleto_novo.nosso_numero_boleto).to eq('000123879890777700168')
+  end
+
+  it 'Calcular agencia_dv' do
+    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo.agencia = '85068014982'
+    expect(boleto_novo.agencia_dv).to eql(9)
+    boleto_novo.agencia = '05009401448'
+    expect(boleto_novo.agencia_dv).to eql(1)
+    boleto_novo.agencia = '12387987777700168'
+    expect(boleto_novo.agencia_dv).to eql(2)
+    boleto_novo.agencia = '4042'
+    expect(boleto_novo.agencia_dv).to eql(8)
+    boleto_novo.agencia = '61900'
+    expect(boleto_novo.agencia_dv).to eql(0)
+    boleto_novo.agencia = '0719'
+    expect(boleto_novo.agencia_dv).to eql(6)
+    boleto_novo.agencia = 85_068_014_982
+    expect(boleto_novo.agencia_dv).to eql(9)
+    boleto_novo.agencia = 5_009_401_448
+    expect(boleto_novo.agencia_dv).to eql(1)
+    boleto_novo.agencia = 12_387_987_777_700_168
+    expect(boleto_novo.agencia_dv).to eql(2)
+    boleto_novo.agencia = 4042
+    expect(boleto_novo.agencia_dv).to eql(8)
+    boleto_novo.agencia = 61_900
+    expect(boleto_novo.agencia_dv).to eql(0)
+    boleto_novo.agencia = 719
+    expect(boleto_novo.agencia_dv).to eql(6)
+  end
+
+  it 'Montar agencia_conta_boleto' do
+    boleto_novo = described_class.new(@valid_attributes)
+
+    expect(boleto_novo.agencia_conta_boleto).to eql('4042-8 / 00061900-0')
+    boleto_novo.agencia = '0719'
+    expect(boleto_novo.agencia_conta_boleto).to eql('0719-6 / 00061900-0')
+    boleto_novo.agencia = '0548'
+    boleto_novo.conta_corrente = '1448'
+    expect(boleto_novo.agencia_conta_boleto).to eql('0548-7 / 00001448-6')
+  end
+
+  it 'Busca logotipo do banco' do
+    boleto_novo = described_class.new
+    expect(File.exist?(boleto_novo.logotipo)).to be_truthy
+    expect(File.stat(boleto_novo.logotipo).zero?).to be_falsey
+  end
+end


### PR DESCRIPTION
### Motivação
A apresentação do boleto banco do brasil não é compatível com a implementação de registro online.

### Solução proposta
Inserir uma nova apresentação p/ boletos online Banco do Brasil

### Screenshoot
![image](https://user-images.githubusercontent.com/31661772/82709797-cdf9a800-9c57-11ea-85ef-472c616a49b4.png)
