### PR TITLE
Corrige geração de boletos com vencimento a partir de 09/2025

### DIFF
--- a/lib/brcobranca/calculo_data.rb
+++ b/lib/brcobranca/calculo_data.rb
@@ -9,7 +9,14 @@ module Brcobranca
     #  Date.parse(2000-07-04).fator_vencimento #=> 1001
     def fator_vencimento
       data_base = Date.parse '1997-10-07'
-      Integer(self - data_base).to_s.rjust(4, '0')
+      fator_vencimento = Integer(self - data_base)
+
+      while fator_vencimento > 9999
+        data_base = data_base + 10000
+        fator_vencimento = Integer(self - data_base) + 1000
+      end
+
+      fator_vencimento.to_s
     end
 
     # Mostra a data em formato <b>dia/mês/ano</b>

--- a/spec/brcobranca/calculo_data_spec.rb
+++ b/spec/brcobranca/calculo_data_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Brcobranca::CalculoData do
+  describe '#fator_vencimento' do
+    it 'Calcula o fator de vencimento' do
+      expect((Date.parse '2008-02-01').fator_vencimento).to eq('3769')
+      expect((Date.parse '2008-02-02').fator_vencimento).to eq('3770')
+      expect((Date.parse '2008-02-06').fator_vencimento).to eq('3774')
+      expect((Date.parse '03/07/2000').fator_vencimento).to eq('1000')
+      expect((Date.parse '04/07/2000').fator_vencimento).to eq('1001')
+      expect((Date.parse '05/07/2000').fator_vencimento).to eq('1002')
+      expect((Date.parse '01/05/2002').fator_vencimento).to eq('1667')
+      expect((Date.parse '17/11/2010').fator_vencimento).to eq('4789')
+      expect((Date.parse '21/02/2025').fator_vencimento).to eq('9999')
+      expect((Date.parse '22/02/2025').fator_vencimento).to eq('1000')
+      expect((Date.parse '23/02/2025').fator_vencimento).to eq('1001')
+    end
+  end
+end

--- a/spec/brcobranca/calculo_data_spec.rb
+++ b/spec/brcobranca/calculo_data_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Brcobranca::CalculoData do
   describe '#fator_vencimento' do
     it 'Calcula o fator de vencimento' do


### PR DESCRIPTION
**Issue:** https://github.com/vindi/recurrent/issues/4412

### Motivação
Alguns clientes não estão conseguindo gerar boletos a partir de 2025.
Isso acontece pois existe uma limitação para a data de vencimento durante a geração do código de barras.
Essa correção já foi realizada na versão oficial [kivanio/brcobranca](https://github.com/kivanio/brcobranca/blob/9bb3defe9e075c9efd94700ab680937c910369a5/lib/brcobranca/calculo_data.rb#L10) e deve ser atualizada no nosso _fork_.

### Solução proposta
Aplicar a correção realizada na versão oficial para que seja possível emitir boletos.

### Explicação oficial
>   Esse método calcula o número de dias corridos entre a <b>data base ("Fixada" em 07.10.1997)</b> e a <b>data de vencimento</b> desejada. Até que chegue a 9999 novamente onde deve ser usada nova data base começando de 1000.
A partir de 22.02.2025, o fator retorna para '1000' adicionando- se '1' a cada dia subsequente a este fator 
Somente serão considerados válidos para pagamento os boletos com 3.000 fatores de vencimento anteriores 
e 5.500 fatores futuros, ambos em relação a data atual. 
Boletos fora deste controle não serão considerados validos para pagamento na rede bancária.
Ex. Hoje é 13/03/2014 (fator 6.001)
Limite para emissão ou pagamento de boletos vencido: 24/12/2005 (fator 3.000)
Limite para emissão ou pagamento de boletos à vencer: 03/04/2029 (fator 2.501)