### PR TITLE
Aumenta o limite de tamanho máximo para conta bancária do Citibank

### DIFF
--- a/lib/brcobranca/boleto/citibank.rb
+++ b/lib/brcobranca/boleto/citibank.rb
@@ -4,7 +4,7 @@ module Brcobranca
     class Citibank < Base
       validates_length_of :agencia, maximum: 4, message: 'deve ser menor ou igual a 4 dígitos.'
       validates_length_of :numero_documento, maximum: 11, message: 'deve ser menor ou igual a 11 dígitos.'
-      validates_length_of :conta_corrente, maximum: 8, message: 'deve ser menor ou igual a 8 dígitos.'
+      validates_length_of :conta_corrente, maximum: 10, message: 'deve ser menor ou igual a 10 dígitos.'
       validates_length_of :carteira, maximum: 3, message: 'deve ser menor ou igual a 3 dígitos.'
 
       # @param (see Brcobranca::Boleto::Base#initialize)


### PR DESCRIPTION
### Motivação

Permitir que contas novas do Citibank passem na validação para geração de boleto.

### Solução proposta
Aumentar o limite de 8 para 10 caracteres na validação de conta bancária do Citibank. 