### PR TITLE
Insere nova classe para boletos Citibank com repasse de informações

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -109,6 +109,7 @@ module Brcobranca
     autoload :SantanderV2,   'brcobranca/boleto/santander_v2'
     autoload :Santander,     'brcobranca/boleto/santander'
     autoload :Citibank,      'brcobranca/boleto/citibank'
+    autoload :CitibankV2,    'brcobranca/boleto/citibank_v2'
 
     # Módulos para classes de template
     module Template

--- a/lib/brcobranca/boleto/citibank_v2.rb
+++ b/lib/brcobranca/boleto/citibank_v2.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  module Boleto
+    # Classe que repassa as regras de negocio implementadas em fontes externas.
+    class CitibankV2 < BaseV2
+      attr_accessor :codigo_barras
+      attr_reader :linha_digitavel
+
+      validates_length_of :agencia, maximum: 4, message: 'deve ser menor ou igual a 4 dígitos.'
+      validates_length_of :numero_documento, maximum: 11, message: 'deve ser menor ou igual a 11 dígitos.'
+      validates_length_of :conta_corrente, maximum: 10, message: 'deve ser menor ou igual a 10 dígitos.'
+      validates_length_of :carteira, maximum: 3, message: 'deve ser menor ou igual a 3 dígitos.'
+
+      LINHA_DIGITAVEL_REGEXP = /^(.{5})(.{5})(.{5})(.{6})(.{5})(.{6})(.{1})(.{14})$/.freeze
+      VALID_LINHA_DIGITAVEL_REGEXP = /^(\d{5})(\d{5})(\d{23})(\d{14})$/.freeze
+
+      # Nova instancia do CibankComRepasseDeRegras
+      # @param (see Brcobranca::Boleto::Base#initialize)
+      def initialize(campos = {})
+        @codigo_barras = campos.dig(:codigo_barras)
+        @linha_digitavel = campos.dig(:linha_digitavel)
+
+        super(campos)
+      end
+
+      # Codigo do banco emissor (3 dígitos sempre)
+      #
+      # @return [String] 3 caracteres numéricos.
+      def banco
+        '745'
+      end
+
+      # Carteira
+      #
+      # @return [String] 2 caracteres numéricos.
+      def carteira=(valor)
+        @carteira = valor.to_s.rjust(2, '0') if valor
+      end
+
+      # Número seqüencial utilizado para identificar o boleto.
+      # @return [String] 11 caracteres numéricos.
+      def numero_documento=(valor)
+        @numero_documento = valor.to_s.rjust(11, '0') if valor
+      end
+
+      def nosso_numero_dv
+        numero_documento.modulo11_9to2_10_como_zero
+      end
+
+      # Nosso número para exibir no boleto.
+      # @return [String]
+      # @example
+      #  boleto.nosso_numero_boleto #=> ""06/00000004042-8"
+      def nosso_numero_boleto
+        "#{carteira}/#{numero_documento}-#{nosso_numero_dv}"
+      end
+
+      # Agência + conta corrente do cliente para exibir no boleto.
+      # @return [String]
+      # @example
+      #  boleto.agencia_conta_boleto #=> "0548-7 / 00001448-6"
+      def agencia_conta_boleto
+        "#{agencia}-#{agencia_dv} / #{conta_corrente}-#{conta_corrente_dv}"
+      end
+
+      def linha_digitavel=(text)
+        unless text =~ VALID_LINHA_DIGITAVEL_REGEXP
+          raise ArgumentError, "#{text} Linha digitável precisa conter 47 caracteres numéricos."
+        end
+
+        @linha_digitavel = text.gsub(LINHA_DIGITAVEL_REGEXP, '\1.\2 \3.\4 \5.\6 \7 \8')
+      end
+    end
+  end
+end

--- a/spec/brcobranca/citibank_v2_spec.rb
+++ b/spec/brcobranca/citibank_v2_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Brcobranca::Boleto::CitibankV2 do
+  before(:each) do
+    @valid_attributes = {
+      especie_documento: 'DS',
+      moeda: '9',
+      data_documento: Date.today,
+      dias_vencimento: 1,
+      aceite: 'N',
+      valor: 25.0,
+      local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
+      cedente: 'Cedente',
+      cedente_endereco: "Endereço do cedente - Endereço do cedente - Endereço do cedente -
+      Endereço do cedente - Endereço do cedente - Endereço do cedente - Endereço do cedente -
+      Endereço do cedente - Endereço do cedente",
+      documento_cedente: '20566973000108',
+      sacado: 'Teste Sacado',
+      sacado_documento: '12979614000146',
+      agencia: '0059',
+      conta_corrente: '119196019',
+      carteira: '101',
+      linha_digitavel: '74593112181919601900400000002998488120000001000',
+      codigo_barras: '74594881200000010003112119196019000000000299',
+      numero_documento: '00000000029',
+      instrucao1: 'Instruções para o beneficiário'
+    }
+  end
+
+  it 'Criar nova instancia com atributos padrões' do
+    boleto_novo = described_class.new
+    expect(boleto_novo.banco).to eql('745')
+    expect(boleto_novo.especie_documento).to eql('DM')
+    expect(boleto_novo.especie).to eql('R$')
+    expect(boleto_novo.moeda).to eql('9')
+    expect(boleto_novo.data_documento).to eql(Date.today)
+    expect(boleto_novo.dias_vencimento).to eql(1)
+    expect(boleto_novo.data_vencimento).to eql(Date.today + 1)
+    expect(boleto_novo.aceite).to eql('S')
+    expect(boleto_novo.quantidade).to eql(1)
+    expect(boleto_novo.valor).to eql(0.0)
+    expect(boleto_novo.valor_documento).to eql(0.0)
+    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+  end
+
+  it 'Criar nova instancia com atributos válidos' do
+    boleto_novo = described_class.new(@valid_attributes)
+    expect(boleto_novo.banco).to eql('745')
+    expect(boleto_novo.especie_documento).to eql('DS')
+    expect(boleto_novo.especie).to eql('R$')
+    expect(boleto_novo.moeda).to eql('9')
+    expect(boleto_novo.data_documento).to eql(Date.today)
+    expect(boleto_novo.dias_vencimento).to eql(1)
+    expect(boleto_novo.data_vencimento).to eql(Date.today + 1)
+    expect(boleto_novo.aceite).to eql('N')
+    expect(boleto_novo.quantidade).to eql(1)
+    expect(boleto_novo.valor).to eql(25.0)
+    expect(boleto_novo.valor_documento).to eql(25.0)
+    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    expect(boleto_novo.cedente).to eql('Cedente')
+    expect(boleto_novo.documento_cedente).to eql('20566973000108')
+    expect(boleto_novo.sacado).to eql('Teste Sacado')
+    expect(boleto_novo.sacado_documento).to eql('12979614000146')
+    expect(boleto_novo.agencia).to eql('0059')
+    expect(boleto_novo.numero_documento).to eql('00000000029')
+    expect(boleto_novo.carteira).to eql('112')
+  end
+
+  it 'Gerar boleto' do
+    @valid_attributes[:data_documento] = Date.parse('2011/10/08')
+    boleto_novo = described_class.new(@valid_attributes)
+    expect(boleto_novo.codigo_barras).to eql('74594881200000010003112119196019000000000299')
+    expect(boleto_novo.linha_digitavel).to eql('74593.11218 19196.019004 00000.002998 4 88120000001000')
+    expect(boleto_novo.nosso_numero_boleto).to eq('112/00000000029-9')
+  end
+
+  it 'Montar nosso_numero_boleto' do
+    boleto_novo = described_class.new(@valid_attributes)
+    expect(boleto_novo.nosso_numero_boleto).to eql('112/00000000029-9')
+  end
+
+  it 'Busca logotipo do banco' do
+    boleto_novo = described_class.new
+    expect(File.exist?(boleto_novo.logotipo)).to be_truthy
+    expect(File.stat(boleto_novo.logotipo).zero?).to be_falsey
+  end
+
+  it 'Gerar boleto nos formatos válidos com método to_' do
+    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(@valid_attributes)
+
+    %w[pdf jpg tif png].each do |format|
+      file_body = boleto_novo.send("to_#{format}".to_sym)
+      tmp_file = Tempfile.new(['foobar', ".#{format}"])
+      tmp_file.puts file_body
+      tmp_file.close
+      expect(File.exist?(tmp_file.path)).to be_truthy
+      expect(File.stat(tmp_file.path).zero?).to be_falsey
+      expect(File.delete(tmp_file.path)).to eql(1)
+      expect(File.exist?(tmp_file.path)).to be_falsey
+    end
+  end
+
+  it 'Gerar boleto nos formatos válidos' do
+    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(@valid_attributes)
+
+    %w[pdf jpg tif png].each do |format|
+      file_body = boleto_novo.to(format)
+      tmp_file = Tempfile.new(['foobar', ".#{format}"])
+      tmp_file.puts file_body
+      tmp_file.close
+      expect(File.exist?(tmp_file.path)).to be_truthy
+      expect(File.stat(tmp_file.path).zero?).to be_falsey
+      expect(File.delete(tmp_file.path)).to eql(1)
+      expect(File.exist?(tmp_file.path)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
## Motivação 💪
Adiciona nova forma de impressão de boletos que recebe dados externos sem reaplicar no Brcobranca regras referentes ao código de barras e linha digitável.

## Como testar
1 - Rodar os testes unitários.
2 - Rodar o teste `spec/brcobranca/citibank_v2_spec.rb` colocar um breakpoint após a linha 119.

Solução proposta 🔧
Cria um novo modelo para o Citibank utilizando a nova maneira (`BaseV2`)  de impressão do boleto que recebe os dados referentes a código de barras e linha digitável.

Riscos ⚠️
1 - Os boletos deixarem de serem gerados.
2 - Os boletos serem gerados com as informações incorretas.

Impactos previstos 💥
Todos os boletos do Citibank Webservice passarão a informar os dados de código de barras e linha digitável retornados pelo Webservice.
