### PR TITLE
Corrigindo bug RGhost::RenderException Permission denied

### DIFF
--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -24,6 +24,7 @@ module Brcobranca
         extend self
         include RGhost unless self.include?(RGhost)
         RGhost::Config::GS[:external_encoding] = Brcobranca.configuration.external_encoding
+        RGhost::Config::GS[:default_params] << '-dNOSAFER'
 
         # Gera o boleto em usando o formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
         #

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -24,6 +24,7 @@ module Brcobranca
         extend self
         include RGhost unless self.include?(RGhost)
         RGhost::Config::GS[:external_encoding] = Brcobranca.configuration.external_encoding
+        RGhost::Config::GS[:default_params] << '-dNOSAFER'
 
         # Gera o boleto em usando o formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
         #


### PR DESCRIPTION
## O que mudou
Corrigindo o bug `RGhost::RenderException Permission denied`

## Motivação
Este bug passou a ocorrer no Semaphore do recurrent, passando a impedir a CI rodar em novos PRs.

## Solução proposta
Correção do bug fazendo ser permitido o acesso do arquivo.

## Como testar
Atualizar a gem usando essa branch no projeto recurrent e rodando os testes.
`spec/models/charge/bank_slip/without_registration_spec.rb:21`
`spec/models/charge/bank_slip/without_registration_spec.rb:142`

## Riscos
O problema persistir.

## Impactos negativos previstos
Nenhum

## Instruções para deploy
Nenhuma

## Instruções pós deploy
Nenhum

## Instruções para retorno
Rollback desse PR
